### PR TITLE
Revert "Merge pull request #1 from NFT-Art-Generator/ignore-engines"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,4 +19,4 @@ if [ -n "$NPM_AUTH_TOKEN" ]; then
   chmod 0600 "$NPM_CONFIG_USERCONFIG"
 fi
 
-sh -c "yarn --ignore-engines $*"
+sh -c "yarn $*"


### PR DESCRIPTION
It didn't fix it (even after updating tag/version)

This reverts commit 2c150cc9a080d60513a14c2ad849975582de19dd.